### PR TITLE
chore: remove unused uuid import from accounts model

### DIFF
--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -1,9 +1,9 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
-import uuid
 from django.conf import settings
 from django.utils import timezone
 from datetime import timedelta
+
 
 class CustomUser(AbstractUser):
     phone = models.CharField(max_length=20, unique=True, null=True, blank=True)
@@ -11,12 +11,18 @@ class CustomUser(AbstractUser):
     def __str__(self):
         return self.username or self.email or self.phone
 
+
 class PasswordResetCode(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    code = models.CharField(max_length=6)  # например 6-значный код
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE
+    )
+    code = models.CharField(max_length=6)  # six-digit code
     created_at = models.DateTimeField(auto_now_add=True)
     is_used = models.BooleanField(default=False)
 
     def is_valid(self):
         # код действителен 10 минут
-        return not self.is_used and (timezone.now() - self.created_at) < timedelta(minutes=10)
+        return (
+            not self.is_used
+            and (timezone.now() - self.created_at) < timedelta(minutes=10)
+        )


### PR DESCRIPTION
## Summary
- remove unused uuid import from accounts model
- tidy formatting to satisfy flake8

## Testing
- `pytest`
- `flake8 backend/accounts/models.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4c6d952b483229c3c5bea776b558e