### PR TITLE
refactor: streamline auth imports

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,10 +1,7 @@
-from django.contrib.auth.models import User
 from rest_framework import serializers
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from rest_framework_simplejwt.tokens import RefreshToken
-from django.contrib.auth import get_user_model
-from .models import PasswordResetCode
-from .models import CustomUser
+from .models import PasswordResetCode, CustomUser
 import random
 from notifications.messaging import send_reset_code_email, send_reset_code_sms
 
@@ -68,8 +65,6 @@ class PasswordResetRequestSerializer(serializers.Serializer):
     def validate(self, data):
         identifier = data["identifier"]
         user = None
-        from django.contrib.auth import get_user_model
-        User = get_user_model()
 
         try:
             user = User.objects.get(email=identifier)
@@ -84,12 +79,10 @@ class PasswordResetRequestSerializer(serializers.Serializer):
         return data
 
     def create(self, validated_data):
-        import random
         user = validated_data["user"]
         method = validated_data["method"]
 
         code = str(random.randint(100000, 999999))
-        from .models import PasswordResetCode
         PasswordResetCode.objects.create(user=user, code=code)
 
         if method == "email":


### PR DESCRIPTION
## Summary
- consolidate imports in account serializers
- drop redundant get_user_model and random imports

## Testing
- `SECRET_KEY=dummy python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c6dc00648322a00ec96c22482365