### PR TITLE
Add logout endpoint with refresh token invalidation

### DIFF
--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,13 +1,17 @@
 from django.urls import path
 from .views import (
-    RegisterView, CustomLoginView,
-    PasswordResetRequestView, PasswordResetConfirmView
+    RegisterView,
+    CustomLoginView,
+    LogoutView,
+    PasswordResetRequestView,
+    PasswordResetConfirmView,
 )
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
     path("register/", RegisterView.as_view(), name="register"),
     path("login/", CustomLoginView.as_view(), name="custom-login"),
+    path("logout/", LogoutView.as_view(), name="logout"),
     path("password-reset/request/", PasswordResetRequestView.as_view(), name="password-reset-request"),
     path("password-reset/confirm/", PasswordResetConfirmView.as_view(), name="password-reset-confirm"),
 ]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     "django.contrib.admin","django.contrib.auth","django.contrib.contenttypes",
     "django.contrib.sessions","django.contrib.messages","django.contrib.staticfiles",
     "rest_framework","corsheaders","drf_spectacular",
+    "rest_framework_simplejwt.token_blacklist",
     "accounts","projects","bids","chat","payments","reviews","notifications",
 ]
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,3 @@
+export default function App() {
+  return null;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import App from './App'
 import Register from './register/Register'
 import Login from './register/Login'
+import Logout from './register/Logout'
 import ResetPasswordRequest from './register/ResetPasswordRequest'
 import ResetPasswordConfirm from './register/ResetPasswordConfirm'
 
@@ -11,6 +13,7 @@ createRoot(document.getElementById('root')!).render(
     <App />
     <Register />
     <Login />
+    <Logout />
     <ResetPasswordRequest />
     <ResetPasswordConfirm />
   </StrictMode>,

--- a/frontend/src/register/Logout.tsx
+++ b/frontend/src/register/Logout.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+export default function Logout() {
+  useEffect(() => {
+    const refresh = localStorage.getItem("refresh");
+    if (refresh) {
+      fetch("http://localhost:8000/api/auth/logout/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh }),
+      }).finally(() => {
+        localStorage.removeItem("access");
+        localStorage.removeItem("refresh");
+        localStorage.removeItem("remember");
+        window.location.href = "/login";
+      });
+    } else {
+      window.location.href = "/login";
+    }
+  }, []);
+
+  return <p>Выход...</p>;
+}


### PR DESCRIPTION
## Summary
- implement LogoutView that blacklists refresh tokens
- register logout route and enable JWT blacklist support
- add frontend logout component and wiring

## Testing
- `SECRET_KEY=test python manage.py test` *(fails: ModuleNotFoundError: No module named 'twilio')*


------
https://chatgpt.com/codex/tasks/task_e_68b4c6dcd4f48322a7bd52af1526d129