### PR TITLE
feat: update login request body

### DIFF
--- a/frontend/src/register/Login.tsx
+++ b/frontend/src/register/Login.tsx
@@ -20,7 +20,7 @@ export default function Login() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          username: form.username,
+          identifier: form.username,
           password: form.password,
         }),
       });
@@ -51,7 +51,7 @@ export default function Login() {
           <input
             type="text"
             name="username"
-            placeholder="Имя пользователя или Email"
+            placeholder="Имя пользователя или email"
             value={form.username}
             onChange={handleChange}
             className="w-full border rounded-lg px-4 py-2"


### PR DESCRIPTION
## Summary
- send identifier instead of username when logging in
- clarify username/email placeholder

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in ResetPassword components)*
- `curl -s -X POST http://localhost:8000/api/auth/login/ -H 'Content-Type: application/json' -d '{"identifier":"testuser","password":"pass1234"}'`


------
https://chatgpt.com/codex/tasks/task_e_68b4c6de176c8322a1ac0d2fd208dfa0