### PR TITLE
feat: capture contact info during registration

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -15,10 +15,18 @@ class RegisterSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ["id", "username", "password"]
+        fields = ["id", "username", "email", "phone", "password"]
+        extra_kwargs = {
+            "email": {"required": False},
+            "phone": {"required": False},
+        }
 
     def create(self, validated_data):
-        user = User(username=validated_data["username"])
+        user = User(
+            username=validated_data["username"],
+            email=validated_data.get("email"),
+            phone=validated_data.get("phone"),
+        )
         user.set_password(validated_data["password"])
         user.save()
         return user

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,4 +1,6 @@
 from rest_framework import generics, permissions
+from rest_framework.response import Response
+from django.contrib.auth import get_user_model
 from .serializers import RegisterSerializer
 from .serializers import LoginSerializer
 from .serializers import PasswordResetRequestSerializer, PasswordResetConfirmSerializer
@@ -6,6 +8,7 @@ from .serializers import PasswordResetRequestSerializer, PasswordResetConfirmSer
 class RegisterView(generics.CreateAPIView):
     serializer_class = RegisterSerializer
     permission_classes = [permissions.AllowAny]
+    queryset = get_user_model().objects.all()
 
 class CustomLoginView(generics.GenericAPIView):
     serializer_class = LoginSerializer

--- a/frontend/src/register/Register.tsx
+++ b/frontend/src/register/Register.tsx
@@ -22,6 +22,8 @@ export default function Register() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         username: form.username,
+        email: form.email,
+        phone: form.phone,
         password: form.password,
       }),
     });


### PR DESCRIPTION
## Summary
- send email and phone during registration
- accept email and phone in register serializer
- expose user queryset in register view

## Testing
- `python -m pytest`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c6e0d8448322b0345bae45ce47c6